### PR TITLE
Add support for merging includes with multiple server block and...

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,6 +4,24 @@ const fs = require('fs')
 const {resolve, dirname} = require('path')
 const glob = require('glob')
 
+/**
+ * Converts ! in back to .
+ * @param key
+ * @return {*|void|string|never}
+ */
+function unsafeKey (key) {
+  return key.replace(new RegExp('(!)', 'g'), '.')
+}
+
+/**
+ * Converts all . in key to !. We need the dot for array access.
+ * @param key
+ * @return {*|void|string|never}
+ */
+function safeKey (key) {
+  return key.replace(new RegExp('(\\.)', 'g'), '!')
+}
+
 module.exports = class Parser {
   constructor () {
     // Last used file name
@@ -41,7 +59,7 @@ module.exports = class Parser {
    */
   resolve (obj, path) {
     return path.split('.').reduce((prev, curr) => {
-      return (typeof prev === 'object' && prev) ? prev[ curr ] : undefined
+      return (typeof prev === 'object' && prev) ? prev[ unsafeKey(curr) ] : undefined
     }, obj)
   }
 
@@ -68,10 +86,10 @@ module.exports = class Parser {
       if (typeof (obj) !== 'object') break
 
       if (components.length === 1) {
-        obj[ components[ 0 ] ] = val
+        obj[ unsafeKey(components[ 0 ]) ] = val
         return true
       } else {
-        obj = obj[ components.shift() ]
+        obj = obj[ unsafeKey(components.shift()) ]
       }
     }
     return false
@@ -184,6 +202,9 @@ module.exports = class Parser {
       // If line is blank line or is comment, do not process it
       if (!line || line.startsWith('#')) return
 
+      // Line can contain comments, we need to remove them
+      line = line.split('#')[0].trim()
+
       /*
         1. Object opening line
         Append key name to `parent` and create the sub-object in `json`
@@ -192,15 +213,18 @@ module.exports = class Parser {
         { "location /api": {} }
       */
       if (line.endsWith('{')) {
-        const key = line.slice(0, line.length - 1).trim()
+        const key = safeKey(line.slice(0, line.length - 1).trim())
 
         // If we are already a level deep (or more), add a dot before the key
         if (parent) parent += '.' + key
         // otherwise just track the key
         else parent = key
 
-        // store in constructed `json`
-        this.resolveSet(json, parent, {})
+        // store in constructed `json` (support array resolving)
+        if (this.appendValue(json, parent, {})) {
+          // Array was used and we need to update the parent key with an index
+          parent += '.' + (this.resolve(json, parent).length - 1)
+        }
 
         /*
           2. Standard inlcude line
@@ -267,6 +291,48 @@ module.exports = class Parser {
   }
 
   /**
+   * Resolve setting value with merging existing value and converting it
+   * to array. When true is returned, an array was used
+   * @return bool
+   */
+
+  resolveAppendSet (json, key, val) {
+    let isInArray = false
+    const existingVal = this.resolve(json, key)
+    if (existingVal) {
+      // If we already have a property in the constructed `json` by
+      // the same name as `key`, convert the stored value from a
+      // String, to an Array of Strings & push the new value in.
+      // Also support merging arrays
+      var mergedValues = []
+
+      // Should we merge new array with existing values?
+      if (Array.isArray(existingVal)) {
+        mergedValues = existingVal
+      } else if (typeof existingVal !== 'undefined') {
+        mergedValues.push(existingVal)
+      }
+
+      // If given value is already array and current existing value is also array,
+      // merge the arrays together
+      if (Array.isArray(val)) {
+        val.forEach(function (value) {
+          mergedValues.push(value)
+        })
+      } else {
+        mergedValues.push(val)
+      }
+
+      val = mergedValues
+      isInArray = true
+    }
+
+    this.resolveSet(json, key, val)
+
+    return isInArray
+  }
+
+  /**
    * Appends given value into json with parent detection -> resolveSet or resolve
    *
    * @param {Object} json
@@ -275,23 +341,13 @@ module.exports = class Parser {
    * @param {string} parent
    */
   appendValue (json, key, val, parent = undefined) {
+    // Key within the parent
     if (parent) {
-      const existingVal = this.resolve(json, parent + '.' + key)
-      if (existingVal) {
-        // If we already have a property in the constructed `json` by
-        // the same name as `key`, convert the stored value from a
-        // String, to an Array of Strings & push the new value in
-        if (Array.isArray(existingVal)) {
-          val = existingVal.concat(val)
-        } else {
-          val = [val, existingVal]
-        }
-      }
-      this.resolveSet(json, parent + '.' + key, val)
+      return this.resolveAppendSet(json, parent + '.' + key, val)
     } else {
       // Top level key/val, just create property in constructed
       // `json` and store val
-      this.resolveSet(json, key, val)
+      return this.resolveAppendSet(json, key, val)
     }
   }
 


### PR DESCRIPTION
HI Carl,

found new use cases and fixed them :)

⛑ Add support for including files that contains multiple server blocks (or multiple same blocks in root). I had two sites that had 2 server blocks. (see `should support multiple same-parent nesting` test)
⛑ Parse lines that contains inline comment server_name test; # Managed by me (see `should support comment on same line as property line` test)
⛑ Allow dots in key name (see `should support dots in keys (like if)` test
👍 Lint fixes in tests

Have great day and thanks 👋