### PR TITLE
Handle multiblock lines

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -235,10 +235,10 @@ module.exports = class Parser {
       /*
         Line can contain multiple blocks
         e.g. "upstream x {server A;} upstream y {server B; server C; server D;}"
-        Make sure '{' and '}' symbols starts from and ends with a new line.
+        Wrap curly brackets in ' {' and '; }' with new line symbols.
         Add new line symbol to all ';',
       */
-      innerLines = lineRaw.replace(/({|})/g,"\n$1\n").replace(/;/g,';\n').split(/\n/)
+      innerLines = lineRaw.replace(/(\s+{)/g,"\n$1\n").replace(/(;\s*)}/g,'$1\n}\n').replace(/;/g,';\n').split(/\n/)
       innerLines.forEach(line => {
         line = line.trim()
         if (!line) return

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -217,6 +217,7 @@ module.exports = class Parser {
     const lines = conf.replace('\t', '').split('\n')
     let json = {} // holds constructed json
     let parent = '' // parent keys as we descend into object
+    let chunkedLine = null // aggregator for multi-lines directives
     let countOfParentsThatAreArrays = 0 // how many of the parent keys are arrays
     let isInLuaBlock = false
     let luaBlockValue = []
@@ -236,6 +237,8 @@ module.exports = class Parser {
       // Line can contain comments, we need to remove them
       line = line.split('#')[0].trim()
 
+      chunkedLine && (line = chunkedLine + " " + line)
+
       /*
         1. Object opening line
         Append key name to `parent` and create the sub-object in `json`
@@ -244,6 +247,7 @@ module.exports = class Parser {
         { "location /api": {} }
       */
       if (line.endsWith('{')) {
+        chunkedLine = null
         const key = safeKey(line.slice(0, line.length - 1).trim())
         if (key.endsWith('by_lua_block')) {
           // flip isInLuaBlock to true to disable parsing of tokens within this block
@@ -267,6 +271,7 @@ module.exports = class Parser {
           Load external file config and merge it into current json structure
         */
       } else if (line.startsWith('include') && options.parseIncludes) {
+        chunkedLine = null
         // Resolve find path in the include (can use wildcard and relative paths)
         const findFiles = resolve(
           this.serverRoot || options.includesRoot || '',
@@ -301,6 +306,7 @@ module.exports = class Parser {
           reflects the key/value in the conf file.
         */
       } else if (line.endsWith(';')) {
+        chunkedLine = null
         line = line.split(' ')
 
         // Put the property name into `key`
@@ -321,6 +327,7 @@ module.exports = class Parser {
           e.g. "server.location /api" becomes "server"
         */
       } else if (line.endsWith('}')) {
+        chunkedLine = null
         // If we're in a lua block, make sure the final value gets stored before moving up a level
         if (isInLuaBlock) {
           this.appendValue(json, '_lua', luaBlockValue, parent)
@@ -338,6 +345,15 @@ module.exports = class Parser {
         }
         parent.pop()
         parent = parent.join('.')
+
+        /*
+          5. Line may not contain '{' ';' '}' symbols at the end
+          e.g. "location /api
+                { ... }"
+          Block begins from the new line here.
+        */
+      } else {
+        chunkedLine = line
       }
     })
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -218,7 +218,7 @@ module.exports = class Parser {
     let json = {} // holds constructed json
     let parent = '' // parent keys as we descend into object
     let chunkedLine = null // aggregator for multi-lines directives
-    let innerLines = [] // array for blocks extracted from multi-blocks line 
+    let innerLines = [] // array for blocks extracted from multi-blocks line
     let countOfParentsThatAreArrays = 0 // how many of the parent keys are arrays
     let isInLuaBlock = false
     let luaBlockValue = []
@@ -236,20 +236,19 @@ module.exports = class Parser {
         Line can contain multiple blocks
         e.g. "upstream x {server A;} upstream y {server B; server C; server D;}"
         Wrap curly brackets in ' {' and '; }' with new line symbols.
-        Add new line symbol to all ';',
+        Add new line after all ';',
       */
       innerLines = lineRaw.replace(/(\s+{)/g,"\n$1\n").replace(/(;\s*)}/g,'$1\n}\n').replace(/;/g,';\n').split(/\n/)
       innerLines.forEach(line => {
         line = line.trim()
         if (!line) return
-  
+
         // If we're in a lua block, append the line to the luaBlockValue and continue
         if (isInLuaBlock && !line.endsWith('}')) {
           luaBlockValue.push(line)
           return
         }
-  
-        // https://github.com/webantic/nginx-config-parser/issues/12
+
         chunkedLine && (line = chunkedLine + " " + line)
 
         /*
@@ -266,19 +265,19 @@ module.exports = class Parser {
             // flip isInLuaBlock to true to disable parsing of tokens within this block
             isInLuaBlock = true
           }
-  
+
           // If we are already a level deep (or more), add a dot before the key
           if (parent) parent += '.' + key
           // otherwise just track the key
           else parent = key
-  
+
           // store in constructed `json` (support array resolving)
           if (this.appendValue(json, parent, {})) {
             // Array was used and we need to update the parent key with an index
             parent += '.' + (this.resolve(json, parent).length - 1)
             countOfParentsThatAreArrays += 1
           }
-  
+
           /*
             2. Standard inlcude line
             Load external file config and merge it into current json structure
@@ -291,31 +290,28 @@ module.exports = class Parser {
             line.replace('include ', '').replace(';', '').trim()
           )
           const files = glob.sync(findFiles)
-  
+
           files.forEach((file) => {
             // Get separate parser that will parse included file
             const parser = new Parser()
             // Pass the current server root - includes in the file
             // must be originating from the conf root
             parser.serverRoot = this.serverRoot
-  
+
             // Include contains path to file, it can be relative/absolute - resolve the path
             const config = parser.readConfigFile(file)
-  
+
             // Get all found key values and resolve in current tree structure
             for (let key in config) {
               const val = config[key]
               this.appendValue(json, key, val, parent)
             }
           })
-  
-          /*
+
           if (!files.length) {
-            process.stdout.write(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}\n`)
-            // throw new ReferenceError(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}`)
+            throw new ReferenceError(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}`)
           }
-          */
-  
+
           /*
             3. Standard property line
             Create a key/value pair in the constructed `json`, which
@@ -324,19 +320,19 @@ module.exports = class Parser {
         } else if (line.endsWith(';')) {
           chunkedLine = null
           line = line.split(' ')
-  
+
           // Put the property name into `key`
-          let key = line.shift()
+          let key = safeKey(line.shift())
           // Put the property value into `val`
           let val = line.join(' ').trim()
-  
+
           // If key ends with a semi-colon, remove that semi-colon
           if (key.endsWith(';')) key = key.slice(0, key.length - 1)
           // Remove trailing semi-colon from `val` (we established its
           // presence already)
           val = val.slice(0, val.length - 1)
           this.appendValue(json, key, val, parent)
-  
+
           /*
             4. Object closing line
             Removes current deepest `key` from `parent`
@@ -350,10 +346,10 @@ module.exports = class Parser {
             luaBlockValue = []
             isInLuaBlock = false
           }
-  
+
           // Pop the parent to go lower
           parent = parent.split('.')
-  
+
           // check if the current level is an array
           if (countOfParentsThatAreArrays > 0 && !isNaN(parseInt(parent[parent.length - 1], 10))) {
             parent.pop() // remove the numeric index from parent
@@ -361,6 +357,13 @@ module.exports = class Parser {
           }
           parent.pop()
           parent = parent.join('.')
+
+          /*
+            5. Line may not contain '{' ';' '}' symbols at the end
+            e.g. "location /api
+                  { ... }"
+            Block begins from the new line here.
+          */
         } else {
           chunkedLine = line
         }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -218,143 +218,153 @@ module.exports = class Parser {
     let json = {} // holds constructed json
     let parent = '' // parent keys as we descend into object
     let chunkedLine = null // aggregator for multi-lines directives
+    let innerLines = [] // array for blocks extracted from multi-blocks line 
     let countOfParentsThatAreArrays = 0 // how many of the parent keys are arrays
     let isInLuaBlock = false
     let luaBlockValue = []
 
-    lines.forEach(line => {
-      line = line.trim() // prep for `startsWith` and `endsWith`
-
-      // If we're in a lua block, append the line to the luaBlockValue and continue
-      if (isInLuaBlock && !line.endsWith('}')) {
-        luaBlockValue.push(line)
-        return
-      }
+    lines.forEach(lineRaw => {
+      lineRaw = lineRaw.trim() // prep for `startsWith` and `endsWith`
 
       // If line is blank line or is comment, do not process it
-      if (!line || line.startsWith('#')) return
+      if (!lineRaw || lineRaw.startsWith('#')) return
 
       // Line can contain comments, we need to remove them
-      line = line.split('#')[0].trim()
-
-      chunkedLine && (line = chunkedLine + " " + line)
+      lineRaw = lineRaw.split('#')[0].trim()
 
       /*
-        1. Object opening line
-        Append key name to `parent` and create the sub-object in `json`
-        e.g. for the line "location /api {", `json` is extended with
-        the following key/value:
-        { "location /api": {} }
+        Line can contain multiple blocks
+        e.g. "upstream x {server A;} upstream y {server B; server C; server D;}"
+        Make sure '{' and '}' symbols starts from and ends with a new line.
+        Add new line symbol to all ';',
       */
-      if (line.endsWith('{')) {
-        chunkedLine = null
-        const key = safeKey(line.slice(0, line.length - 1).trim())
-        if (key.endsWith('by_lua_block')) {
-          // flip isInLuaBlock to true to disable parsing of tokens within this block
-          isInLuaBlock = true
+      innerLines = lineRaw.replace(/({|})/g,"\n$1\n").replace(/;/g,';\n').split(/\n/)
+      innerLines.forEach(line => {
+        line = line.trim()
+        if (!line) return
+  
+        // If we're in a lua block, append the line to the luaBlockValue and continue
+        if (isInLuaBlock && !line.endsWith('}')) {
+          luaBlockValue.push(line)
+          return
         }
-
-        // If we are already a level deep (or more), add a dot before the key
-        if (parent) parent += '.' + key
-        // otherwise just track the key
-        else parent = key
-
-        // store in constructed `json` (support array resolving)
-        if (this.appendValue(json, parent, {})) {
-          // Array was used and we need to update the parent key with an index
-          parent += '.' + (this.resolve(json, parent).length - 1)
-          countOfParentsThatAreArrays += 1
-        }
+  
+        // https://github.com/webantic/nginx-config-parser/issues/12
+        chunkedLine && (line = chunkedLine + " " + line)
 
         /*
-          2. Standard inlcude line
-          Load external file config and merge it into current json structure
+          1. Object opening line
+          Append key name to `parent` and create the sub-object in `json`
+          e.g. for the line "location /api {", `json` is extended with
+          the following key/value:
+          { "location /api": {} }
         */
-      } else if (line.startsWith('include') && options.parseIncludes) {
-        chunkedLine = null
-        // Resolve find path in the include (can use wildcard and relative paths)
-        const findFiles = resolve(
-          this.serverRoot || options.includesRoot || '',
-          line.replace('include ', '').replace(';', '').trim()
-        )
-        const files = glob.sync(findFiles)
-
-        files.forEach((file) => {
-          // Get separate parser that will parse included file
-          const parser = new Parser()
-          // Pass the current server root - includes in the file
-          // must be originating from the conf root
-          parser.serverRoot = this.serverRoot
-
-          // Include contains path to file, it can be relative/absolute - resolve the path
-          const config = parser.readConfigFile(file)
-
-          // Get all found key values and resolve in current tree structure
-          for (let key in config) {
-            const val = config[key]
-            this.appendValue(json, key, val, parent)
+        if (line.endsWith('{')) {
+          chunkedLine = null
+          const key = safeKey(line.slice(0, line.length - 1).trim())
+          if (key.endsWith('by_lua_block')) {
+            // flip isInLuaBlock to true to disable parsing of tokens within this block
+            isInLuaBlock = true
           }
-        })
-
-        if (!files.length) {
-          throw new ReferenceError(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}`)
+  
+          // If we are already a level deep (or more), add a dot before the key
+          if (parent) parent += '.' + key
+          // otherwise just track the key
+          else parent = key
+  
+          // store in constructed `json` (support array resolving)
+          if (this.appendValue(json, parent, {})) {
+            // Array was used and we need to update the parent key with an index
+            parent += '.' + (this.resolve(json, parent).length - 1)
+            countOfParentsThatAreArrays += 1
+          }
+  
+          /*
+            2. Standard inlcude line
+            Load external file config and merge it into current json structure
+          */
+        } else if (line.startsWith('include') && options.parseIncludes) {
+          chunkedLine = null
+          // Resolve find path in the include (can use wildcard and relative paths)
+          const findFiles = resolve(
+            this.serverRoot || options.includesRoot || '',
+            line.replace('include ', '').replace(';', '').trim()
+          )
+          const files = glob.sync(findFiles)
+  
+          files.forEach((file) => {
+            // Get separate parser that will parse included file
+            const parser = new Parser()
+            // Pass the current server root - includes in the file
+            // must be originating from the conf root
+            parser.serverRoot = this.serverRoot
+  
+            // Include contains path to file, it can be relative/absolute - resolve the path
+            const config = parser.readConfigFile(file)
+  
+            // Get all found key values and resolve in current tree structure
+            for (let key in config) {
+              const val = config[key]
+              this.appendValue(json, key, val, parent)
+            }
+          })
+  
+          /*
+          if (!files.length) {
+            process.stdout.write(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}\n`)
+            // throw new ReferenceError(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}`)
+          }
+          */
+  
+          /*
+            3. Standard property line
+            Create a key/value pair in the constructed `json`, which
+            reflects the key/value in the conf file.
+          */
+        } else if (line.endsWith(';')) {
+          chunkedLine = null
+          line = line.split(' ')
+  
+          // Put the property name into `key`
+          let key = line.shift()
+          // Put the property value into `val`
+          let val = line.join(' ').trim()
+  
+          // If key ends with a semi-colon, remove that semi-colon
+          if (key.endsWith(';')) key = key.slice(0, key.length - 1)
+          // Remove trailing semi-colon from `val` (we established its
+          // presence already)
+          val = val.slice(0, val.length - 1)
+          this.appendValue(json, key, val, parent)
+  
+          /*
+            4. Object closing line
+            Removes current deepest `key` from `parent`
+            e.g. "server.location /api" becomes "server"
+          */
+        } else if (line.endsWith('}')) {
+          chunkedLine = null
+          // If we're in a lua block, make sure the final value gets stored before moving up a level
+          if (isInLuaBlock) {
+            this.appendValue(json, '_lua', luaBlockValue, parent)
+            luaBlockValue = []
+            isInLuaBlock = false
+          }
+  
+          // Pop the parent to go lower
+          parent = parent.split('.')
+  
+          // check if the current level is an array
+          if (countOfParentsThatAreArrays > 0 && !isNaN(parseInt(parent[parent.length - 1], 10))) {
+            parent.pop() // remove the numeric index from parent
+            countOfParentsThatAreArrays -= 1
+          }
+          parent.pop()
+          parent = parent.join('.')
+        } else {
+          chunkedLine = line
         }
-
-        /*
-          3. Standard property line
-          Create a key/value pair in the constructed `json`, which
-          reflects the key/value in the conf file.
-        */
-      } else if (line.endsWith(';')) {
-        chunkedLine = null
-        line = line.split(' ')
-
-        // Put the property name into `key`
-        let key = line.shift()
-        // Put the property value into `val`
-        let val = line.join(' ').trim()
-
-        // If key ends with a semi-colon, remove that semi-colon
-        if (key.endsWith(';')) key = key.slice(0, key.length - 1)
-        // Remove trailing semi-colon from `val` (we established its
-        // presence already)
-        val = val.slice(0, val.length - 1)
-        this.appendValue(json, key, val, parent)
-
-        /*
-          4. Object closing line
-          Removes current deepest `key` from `parent`
-          e.g. "server.location /api" becomes "server"
-        */
-      } else if (line.endsWith('}')) {
-        chunkedLine = null
-        // If we're in a lua block, make sure the final value gets stored before moving up a level
-        if (isInLuaBlock) {
-          this.appendValue(json, '_lua', luaBlockValue, parent)
-          luaBlockValue = []
-          isInLuaBlock = false
-        }
-
-        // Pop the parent to go lower
-        parent = parent.split('.')
-
-        // check if the current level is an array
-        if (countOfParentsThatAreArrays > 0 && !isNaN(parseInt(parent[parent.length - 1], 10))) {
-          parent.pop() // remove the numeric index from parent
-          countOfParentsThatAreArrays -= 1
-        }
-        parent.pop()
-        parent = parent.join('.')
-
-        /*
-          5. Line may not contain '{' ';' '}' symbols at the end
-          e.g. "location /api
-                { ... }"
-          Block begins from the new line here.
-        */
-      } else {
-        chunkedLine = line
-      }
+      })
     })
 
     return json


### PR DESCRIPTION
Nginx config file can contain multi-block lines like this:

_"upstream test-test1 {server 1.2.3.4:1234;} upstream test-test2 {server 1.1.1.1:1234;  server 2.2.2.2:1235; server 3.3.3.3:3333;}"_

And It breaks current parser.

Propose a fix in current PR. (includes previous PR fixing issue-12)