### PR TITLE
safekey-for-standard-property

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -304,7 +304,7 @@ module.exports = class Parser {
         line = line.split(' ')
 
         // Put the property name into `key`
-        let key = line.shift()
+        let key = safeKey(line.shift())
         // Put the property value into `val`
         let val = line.join(' ').trim()
 


### PR DESCRIPTION
Use safeKey() for 'dotted' keys in maps like this one:

geo $limited {
    default 1;
    10.0.0.0/8 0;
}