### PR TITLE
fix #22

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -241,7 +241,7 @@ module.exports = class Parser {
       innerLines = lineRaw
         .replace(/(\s+{)/g, '\n$1\n')
         .replace(/(;\s*)}/g, '$1\n}\n')
-        .replace(/;/g, ';\n')
+        .replace(/;\s*?$/g, ';\n')
         .split(/\n/)
 
       innerLines.forEach(line => {

--- a/test/parser.js
+++ b/test/parser.js
@@ -163,6 +163,18 @@ describe('toJSON', () => {
 
     parser.toJSON(configString).should.deep.equal({ 'geo $limited': { default: '1', '10.0.0.0/8': '0' } })
   })
+
+  it('should handle multiple semicolon in single line', () => {
+    // attempt to fix issue [#22](https://github.com/webantic/nginx-config-parser/issues/22)
+    const configString = [
+      'server {',
+      '    add_header Strict-Transport-Security "max-age=0; includeSubDomains" always;',
+      '}'
+    ].join('\n');
+
+    parser.toJSON(configString).should.deep.equal({server: {add_header:
+      `Strict-Transport-Security "max-age=0; includeSubDomains" always`}});
+  })
 })
 
 describe('toConf', () => {


### PR DESCRIPTION
## Fix

- Split only the last semicolon of each line into one line. ([#22](https://github.com/webantic/nginx-config-parser/issues/22))