### PR TITLE
Exception removed when an include glob pattern returns no match.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -312,10 +312,6 @@ module.exports = class Parser {
               this.appendValue(json, key, val, parent)
             }
           })
-
-          if (!files.length) {
-            throw new ReferenceError(`Unable to resolve include statement: "${line}".\nSearched in ${this.serverRoot || options.includesRoot || process.cwd()}`)
-          }
         }
         /*
           3. Standard property line


### PR DESCRIPTION
This is a blocking point when loading .conf files, the default behavior of NGINX is to continue the parsing even if there is no file to include.