### PR TITLE
Improved default options

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -115,10 +115,9 @@ module.exports = class Parser {
       cb = undefined
     }
 
-    if (!options) {
-      options = {
-        parseIncludes: true
-      }
+    options = {
+      parseIncludes: true,
+      ...(options || {})
     }
 
     if (cb) {


### PR DESCRIPTION
Not a blocking point but a suggestion, when I use the new version 1.6.1, I had to give a value to the `options` parameter to change `ignoreIncludeErrors` to `true` and I lost the `parseIncludes` to `true ` default behavior, I think the way I wrote is better if you like.